### PR TITLE
Integrate OpenAI API for AI chat responses

### DIFF
--- a/fontend/.gitignore
+++ b/fontend/.gitignore
@@ -25,3 +25,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+
+.history/
+.env.local

--- a/fontend/app/api/ai-chat/route.ts
+++ b/fontend/app/api/ai-chat/route.ts
@@ -1,114 +1,40 @@
-import { type NextRequest, NextResponse } from "next/server"
+import { NextRequest, NextResponse } from 'next/server'
 
-// Mock AI response - In production, this would integrate with OpenAI API
-export async function POST(request: NextRequest) {
-  try {
-    const { message, context } = await request.json()
+export async function POST(req: NextRequest) {
+  const { message } = await req.json()
 
-    // Simulate AI processing delay
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        {
+          role: 'system',
+          content: `
+            Bạn là trợ lý tư vấn OG Camping, hãy trả lời ngắn gọn, thân thiện, tư vấn về gói cắm trại phù hợp cho khách hàng Việt Nam.
+            Một số gói tiêu biểu:
+            - Gói gia đình Đà Lạt: 3.2 triệu, lều lớn, BBQ, an toàn trẻ em
+            - Gói Phú Quốc: 1.8 triệu, biển
+            - Gói Sapa: 2.5 triệu, núi
+          `,
+        },
+        {
+          role: 'user',
+          content: message,
+        },
+      ],
+    }),
+  })
 
-    // Generate contextual response based on message content
-    const response = generateAIResponse(message, context)
+  const data = await response.json()
+  const reply = data.choices?.[0]?.message?.content || 'Xin lỗi, tôi không hiểu câu hỏi của bạn.'
+  
+  // Log the raw response for debugging
+  console.log('OpenAI raw response:', JSON.stringify(data, null, 2))
 
-    return NextResponse.json({
-      success: true,
-      response: response,
-      timestamp: new Date().toISOString(),
-    })
-  } catch (error) {
-    return NextResponse.json({ success: false, error: "Failed to process AI request" }, { status: 500 })
-  }
-}
-
-function generateAIResponse(message: string, context?: any): string {
-  const lowerMessage = message.toLowerCase()
-
-  // Camping service recommendations
-  if (lowerMessage.includes("gia đình") || lowerMessage.includes("family")) {
-    return `Tuyệt vời! Dựa trên nhu cầu cắm trại gia đình của bạn, tôi khuyên bạn nên xem xét:
-
-🏕️ **Gói Cắm trại gia đình Đà Lạt** - 3.200.000đ
-• Thời gian: 2-4 ngày
-• Phù hợp: 6-10 người
-• Bao gồm: Lều lớn, hoạt động trẻ em, BBQ
-• Đánh giá: 4.7/5 ⭐
-
-Gói này có nhiều hoạt động an toàn cho trẻ em và không gian rộng rãi. Bạn có muốn tôi tư vấn thêm về chi tiết không?`
-  }
-
-  if (lowerMessage.includes("mới bắt đầu") || lowerMessage.includes("beginner") || lowerMessage.includes("người mới")) {
-    return `Với người mới bắt đầu, tôi khuyên bạn nên chọn:
-
-🌊 **Gói Cắm trại bãi biển Phú Quốc** - 1.800.000đ
-• Thời gian: 1-2 ngày (phù hợp để làm quen)
-• Có hướng dẫn viên kinh nghiệm
-• Thiết bị đầy đủ, không cần chuẩn bị gì
-• Hoạt động đa dạng: lặn, BBQ
-
-Đây là lựa chọn tuyệt vời để bắt đầu hành trình cắm trại của bạn! Bạn có muốn biết thêm về chuẩn bị gì không?`
-  }
-
-  if (lowerMessage.includes("thiết bị") || lowerMessage.includes("equipment")) {
-    return `Dựa trên loại hình cắm trại bạn quan tâm, tôi gợi ý những thiết bị cần thiết:
-
-🎒 **Thiết bị cơ bản:**
-• Lều cắm trại 4 người - 150.000đ/ngày
-• Túi ngủ cao cấp - 120.000đ/ngày  
-• Đèn pin LED siêu sáng - 50.000đ/ngày
-• Bếp gas mini - 80.000đ/ngày
-
-💡 **Gợi ý:** Nếu đi cắm trại núi, nên thuê thêm áo ấm và giày trekking. Bạn có muốn tôi tư vấn gói thiết bị phù hợp không?`
-  }
-
-  if (lowerMessage.includes("giá") || lowerMessage.includes("price") || lowerMessage.includes("budget")) {
-    return `Tôi hiểu bạn quan tâm đến giá cả. Dưới đây là các gói theo mức giá:
-
-💰 **Dưới 2 triệu:**
-• Cắm trại biển Phú Quốc - 1.800.000đ
-• Cắm trại sa mạc Mũi Né - 1.500.000đ
-
-💰 **2-3 triệu:**
-• Cắm trại núi Sapa - 2.500.000đ
-• Cắm trại rừng Cát Tiên - 2.800.000đ
-
-💰 **Trên 3 triệu:**
-• Cắm trại gia đình Đà Lạt - 3.200.000đ
-• Cắm trại quốc tế Bali - 4.500.000đ
-
-Bạn có ngân sách dự kiến bao nhiêu để tôi tư vấn chính xác hơn?`
-  }
-
-  if (lowerMessage.includes("so sánh") || lowerMessage.includes("compare")) {
-    return `Tôi sẽ so sánh 2 gói phổ biến nhất:
-
-🏔️ **Cắm trại núi Sapa** vs 🏖️ **Cắm trại biển Phú Quốc**
-
-**Sapa:**
-✅ Khí hậu mát mẻ, view núi đẹp
-✅ Hoạt động trekking thú vị
-❌ Thời tiết có thể lạnh, khó khăn hơn
-
-**Phú Quốc:**
-✅ Thời tiết ấm áp, dễ chịu
-✅ Hoạt động biển đa dạng
-❌ Có thể đông khách vào mùa cao điểm
-
-Bạn thích khám phá núi hay biển hơn?`
-  }
-
-  // Default responses
-  const defaultResponses = [
-    `Cảm ơn bạn đã chia sẻ! Để tư vấn chính xác nhất, bạn có thể cho tôi biết thêm về:
-• Số người tham gia?
-• Thời gian dự kiến (bao nhiêu ngày)?
-• Ngân sách dự tính?
-• Loại địa điểm yêu thích (núi, biển, rừng...)?`,
-
-    `Tôi hiểu nhu cầu của bạn. Dựa trên thông tin này, tôi sẽ phân tích và đưa ra những gợi ý phù hợp nhất. Bạn có thể cung cấp thêm thông tin về ngân sách và số người tham gia không?`,
-
-    `Đây là câu hỏi rất hay! Tôi sẽ giúp bạn tìm ra giải pháp tốt nhất. Để tư vấn chính xác, bạn có thể chia sẻ thêm về kinh nghiệm cắm trại và sở thích cá nhân không?`,
-  ]
-
-  return defaultResponses[Math.floor(Math.random() * defaultResponses.length)]
+  return NextResponse.json({ reply })
 }

--- a/fontend/components/chat-bot.tsx
+++ b/fontend/components/chat-bot.tsx
@@ -90,12 +90,13 @@ export default function ChatBot({ initialMessages = [] }: ChatBotProps) {
     setInputMessage("")
     setIsTyping(true)
 
-    // Simulate AI response
-    setTimeout(() => {
+    // Simulate AI response with async/await
+    setTimeout(async () => {
+      const aiReply = await generateAIResponse(inputMessage)
       const aiResponse: Message = {
         id: messages.length + 2,
         type: "bot",
-        content: generateAIResponse(inputMessage),
+        content: aiReply,
         timestamp: new Date(),
       }
       setMessages((prev) => [...prev, aiResponse])
@@ -103,56 +104,73 @@ export default function ChatBot({ initialMessages = [] }: ChatBotProps) {
     }, 1500)
   }
 
-  const generateAIResponse = (userMessage: string) => {
-    const lowerMessage = userMessage.toLowerCase()
+//   const generateAIResponse = (userMessage: string) => {
+//     const lowerMessage = userMessage.toLowerCase()
 
-    if (lowerMessage.includes("gia đình")) {
-      return `Tuyệt vời! Dựa trên nhu cầu cắm trại gia đình của bạn, tôi khuyên bạn nên xem xét:
+//     if (lowerMessage.includes("gia đình")) {
+//       return `Tuyệt vời! Dựa trên nhu cầu cắm trại gia đình của bạn, tôi khuyên bạn nên xem xét:
 
-🏕️ **Gói Cắm trại gia đình Đà Lạt** - 3.200.000đ
-• Thời gian: 2-4 ngày
-• Phù hợp: 6-10 người
-• Bao gồm: Lều lớn, hoạt động trẻ em, BBQ
-• Đánh giá: 4.7/5 ⭐
+// 🏕️ **Gói Cắm trại gia đình Đà Lạt** - 3.200.000đ
+// • Thời gian: 2-4 ngày
+// • Phù hợp: 6-10 người
+// • Bao gồm: Lều lớn, hoạt động trẻ em, BBQ
+// • Đánh giá: 4.7/5 ⭐
 
-Gói này có nhiều hoạt động an toàn cho trẻ em và không gian rộng rãi. Bạn có muốn tôi tư vấn thêm về chi tiết không?`
-    }
+// Gói này có nhiều hoạt động an toàn cho trẻ em và không gian rộng rãi. Bạn có muốn tôi tư vấn thêm về chi tiết không?`
+//     }
 
-    if (lowerMessage.includes("thiết bị")) {
-      return `Dựa trên loại hình cắm trại bạn quan tâm, tôi gợi ý những thiết bị cần thiết:
+//     if (lowerMessage.includes("thiết bị")) {
+//       return `Dựa trên loại hình cắm trại bạn quan tâm, tôi gợi ý những thiết bị cần thiết:
 
-🎒 **Thiết bị cơ bản:**
-• Lều cắm trại 4 người - 150.000đ/ngày
-• Túi ngủ cao cấp - 120.000đ/ngày  
-• Đèn pin LED siêu sáng - 50.000đ/ngày
-• Bếp gas mini - 80.000đ/ngày
+// 🎒 **Thiết bị cơ bản:**
+// • Lều cắm trại 4 người - 150.000đ/ngày
+// • Túi ngủ cao cấp - 120.000đ/ngày  
+// • Đèn pin LED siêu sáng - 50.000đ/ngày
+// • Bếp gas mini - 80.000đ/ngày
 
-💡 **Gợi ý:** Nếu đi cắm trại núi, nên thuê thêm áo ấm và giày trekking. Bạn có muốn tôi tư vấn gói thiết bị phù hợp không?`
-    }
+// 💡 **Gợi ý:** Nếu đi cắm trại núi, nên thuê thêm áo ấm và giày trekking. Bạn có muốn tôi tư vấn gói thiết bị phù hợp không?`
+//     }
 
-    if (lowerMessage.includes("giá") || lowerMessage.includes("so sánh")) {
-      return `Tôi hiểu bạn quan tâm đến giá cả. Dưới đây là các gói theo mức giá:
+//     if (lowerMessage.includes("giá") || lowerMessage.includes("so sánh")) {
+//       return `Tôi hiểu bạn quan tâm đến giá cả. Dưới đây là các gói theo mức giá:
 
-💰 **Dưới 2 triệu:**
-• Cắm trại biển Phú Quốc - 1.800.000đ
-• Cắm trại sa mạc Mũi Né - 1.500.000đ
+// 💰 **Dưới 2 triệu:**
+// • Cắm trại biển Phú Quốc - 1.800.000đ
+// • Cắm trại sa mạc Mũi Né - 1.500.000đ
 
-💰 **2-3 triệu:**
-• Cắm trại núi Sapa - 2.500.000đ
-• Cắm trại rừng Cát Tiên - 2.800.000đ
+// 💰 **2-3 triệu:**
+// • Cắm trại núi Sapa - 2.500.000đ
+// • Cắm trại rừng Cát Tiên - 2.800.000đ
 
-💰 **Trên 3 triệu:**
-• Cắm trại gia đình Đà Lạt - 3.200.000đ
+// 💰 **Trên 3 triệu:**
+// • Cắm trại gia đình Đà Lạt - 3.200.000đ
 
-Bạn có ngân sách dự kiến bao nhiêu để tôi tư vấn chính xác hơn?`
-    }
+// Bạn có ngân sách dự kiến bao nhiêu để tôi tư vấn chính xác hơn?`
+//     }
 
-    return `Cảm ơn bạn đã chia sẻ! Để tư vấn chính xác nhất, bạn có thể cho tôi biết thêm về:
-• Số người tham gia?
-• Thời gian dự kiến (bao nhiêu ngày)?
-• Ngân sách dự tính?
-• Loại địa điểm yêu thích (núi, biển, rừng...)?`
+//     return `Cảm ơn bạn đã chia sẻ! Để tư vấn chính xác nhất, bạn có thể cho tôi biết thêm về:
+// • Số người tham gia?
+// • Thời gian dự kiến (bao nhiêu ngày)?
+// • Ngân sách dự tính?
+// • Loại địa điểm yêu thích (núi, biển, rừng...)?`
+//   }
+const generateAIResponse = async (userMessage: string): Promise<string> => {
+  try {
+    const res = await fetch('/api/ai-chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ message: userMessage }),
+    })
+
+    const data = await res.json()
+    return data.reply
+  } catch (error) {
+    console.error('Lỗi khi gọi OpenAI:', error)
+    return 'Xin lỗi, có lỗi xảy ra khi kết nối AI.'
   }
+}
 
   const handleQuickQuestion = (question: string) => {
     setInputMessage(question)


### PR DESCRIPTION
Replaced the mock AI response logic in the API route and chat-bot component with real-time calls to the OpenAI API (gpt-3.5-turbo). Updated .gitignore to exclude .env.local and .history