### PR TITLE
Sync service rating and review count in backend and UI

### DIFF
--- a/backendOG/src/main/java/com/mytech/backend/portal/services/Review/ReviewServiceImpl.java
+++ b/backendOG/src/main/java/com/mytech/backend/portal/services/Review/ReviewServiceImpl.java
@@ -59,12 +59,14 @@ public class ReviewServiceImpl implements ReviewService {
                 .build();
 
         reviewRepository.save(review);
-
+        
+        //  Cập nhật rating cho service
+        updateServiceRating(service, review.getRating());
         return mapToResponse(review);
     }
     
 
-    // ✅ Thêm mới: nhận MultipartFile (upload ảnh/video thật sự)
+    // Thêm mới: nhận MultipartFile (upload ảnh/video thật sự)
     @Override
     public ReviewResponseDTO createReviewWithFiles(
             Long customerId,
@@ -89,7 +91,7 @@ public class ReviewServiceImpl implements ReviewService {
                 .reply(null)
                 .build();
 
-        // ✅ Upload file & convert sang URL
+        // Upload file & convert sang URL
         List<String> imageUrls = new ArrayList<>();
         if (images != null) {
             for (MultipartFile img : images) {
@@ -109,18 +111,22 @@ public class ReviewServiceImpl implements ReviewService {
 
         reviewRepository.save(review);
         
-     // ✅ Cập nhật averageRating & reviewCount trong Service
-//        int oldCount = service.getReviewCount();
-//        double oldAvg = service.getAverageRating();
-//
-//        double newAvg = ((oldAvg * oldCount) + review.getRating()) / (oldCount + 1);
-//
-//        service.setReviewCount(oldCount + 1);
-//        service.setAverageRating(newAvg);
-//
-//        serviceRepository.save(service);
+        // Cập nhật totalReviews & averageRating trong Service
+        updateServiceRating(service, review.getRating());
 
         return mapToResponse(review);
+    }
+    
+    private void updateServiceRating(com.mytech.backend.portal.models.Service.Service service, Integer newRating) {
+        int oldCount = service.getTotalReviews() != null ? service.getTotalReviews() : 0;
+        double oldAvg = service.getAverageRating() != null ? service.getAverageRating() : 0.0;
+
+        double newAvg = ((oldAvg * oldCount) + newRating) / (oldCount + 1);
+
+        service.setTotalReviews(oldCount + 1);
+        service.setAverageRating(newAvg);
+
+        serviceRepository.save(service);
     }
 
     // ✅ Hàm helper để lưu file

--- a/fontend/components/ui/Reviews.tsx
+++ b/fontend/components/ui/Reviews.tsx
@@ -24,6 +24,11 @@ type Review = {
   createdAt: string;
 };
 
+type ServiceInfo = {
+  averageRating: number;
+  totalReviews: number;
+};
+
 type MediaItem = {
   type: "image" | "video";
   url: string;
@@ -32,6 +37,7 @@ type MediaItem = {
 export default function Reviews({ serviceId }: { serviceId: number }) {
   const { user, token, isLoggedIn } = useAuth();
   const [reviews, setReviews] = useState<Review[]>([]);
+  const [serviceInfo, setServiceInfo] = useState<ServiceInfo | null>(null);
   const [content, setContent] = useState("");
   const [rating, setRating] = useState<number>(5);
   const [files, setFiles] = useState<File[]>([]);
@@ -69,6 +75,21 @@ export default function Reviews({ serviceId }: { serviceId: number }) {
       console.error("Error fetching reviews:", err);
     }
   };
+
+  // Lấy thông tin service (để hiển thị rating trung bình, tổng số review)
+  const fetchServiceInfo = async () => {
+  try {
+    const res = await axios.get(
+      `http://localhost:8080/apis/v1/services/${serviceId}`
+    );
+    setServiceInfo({
+      averageRating: res.data.averageRating || 0,
+      totalReviews: res.data.totalReviews || 0,
+    });
+  } catch (err) {
+    console.error("Error fetching service info:", err);
+  }
+};
 
   // Submit review mới
   const submitReview = async () => {
@@ -114,6 +135,7 @@ export default function Reviews({ serviceId }: { serviceId: number }) {
       setRating(5);
       setFiles([]);
       fetchReviews(); // reload danh sách review
+      fetchServiceInfo();
     } catch (err) {
       console.error("Error submitting review:", err);
     }
@@ -149,6 +171,7 @@ export default function Reviews({ serviceId }: { serviceId: number }) {
 
   useEffect(() => {
     fetchReviews();
+    fetchServiceInfo();
   }, [serviceId]);
 
   // clamp currentPage nếu số trang thay đổi (ví dụ xóa review làm giảm totalPages)
@@ -175,15 +198,10 @@ export default function Reviews({ serviceId }: { serviceId: number }) {
           <div className="flex items-center gap-2">
             <Star className="w-5 h-5 fill-yellow-400 text-yellow-400" />
             <span className="font-semibold">
-              {reviews.length > 0
-                ? (
-                    reviews.reduce((sum, r) => sum + r.rating, 0) /
-                    reviews.length
-                  ).toFixed(1)
-                : "0"}
+                {serviceInfo ? serviceInfo.averageRating.toFixed(1) : "0"}
             </span>
             <span className="text-gray-500">
-              ({reviews.length} đánh giá)
+              ({serviceInfo ? serviceInfo.totalReviews : 0} đánh giá)
             </span>
           </div>
         </div>


### PR DESCRIPTION
Refactored backend to update service's average rating and total reviews when a new review is created. Updated frontend to fetch and display service rating and review count from backend instead of calculating locally.